### PR TITLE
Updated the links to use MARKETING_SITE_BASE_URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@edx/frontend-component-header",
+  "name": "@mitodl/frontend-component-header-mitol",
   "version": "1.0.0-semantically-released",
-  "description": "The standard header for Open edX",
+  "description": "The standard header for MITx",
   "main": "dist/index.js",
   "publishConfig": {
     "access": "public"
@@ -24,14 +24,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/edx/frontend-component-header.git"
+    "url": "git+https://github.com/mitodl/frontend-component-header-mitol.git"
   },
-  "author": "edX",
+  "author": "MIT",
   "license": "AGPL-3.0",
   "bugs": {
-    "url": "https://github.com/edx/frontend-component-header/issues"
+    "url": "https://github.com/mitodl/frontend-component-header-mitol/issues"
   },
-  "homepage": "https://github.com/edx/frontend-component-header#readme",
+  "homepage": "https://github.com/mitodl/frontend-component-header-mitol#readme",
   "devDependencies": {
     "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
     "@edx/frontend-build": "5.6.14",

--- a/src/learning-header/AuthenticatedUserDropdown.jsx
+++ b/src/learning-header/AuthenticatedUserDropdown.jsx
@@ -12,7 +12,7 @@ import messages from './messages';
 
 function AuthenticatedUserDropdown({ intl, username }) {
   const dashboardMenuItem = (
-    <Dropdown.Item href={`${getConfig().LMS_BASE_URL}/dashboard`}>
+    <Dropdown.Item href={`${process.env.MARKETING_SITE_BASE_URL}/dashboard`}>
       {intl.formatMessage(messages.dashboard)}
     </Dropdown.Item>
   );
@@ -29,7 +29,7 @@ function AuthenticatedUserDropdown({ intl, username }) {
         </Dropdown.Toggle>
         <Dropdown.Menu className="dropdown-menu-right">
           {dashboardMenuItem}
-          <Dropdown.Item href={`${getConfig().LMS_BASE_URL}/u/${username}`}>
+          <Dropdown.Item href={`${process.env.MARKETING_SITE_BASE_URL}/u/${username}`}>
             {intl.formatMessage(messages.profile)}
           </Dropdown.Item>
           <Dropdown.Item href={`${getConfig().LMS_BASE_URL}/account/settings`}>

--- a/src/learning-header/AuthenticatedUserDropdown.jsx
+++ b/src/learning-header/AuthenticatedUserDropdown.jsx
@@ -32,8 +32,8 @@ function AuthenticatedUserDropdown({ intl, username }) {
           <Dropdown.Item href={`${getConfig().MARKETING_SITE_BASE_URL}/u/${username}`}>
             {intl.formatMessage(messages.profile)}
           </Dropdown.Item>
-          <Dropdown.Item href={`${getConfig().LMS_BASE_URL}/account/settings`}>
-            {intl.formatMessage(messages.account)}
+          <Dropdown.Item href={`${getConfig().MARKETING_SITE_BASE_URL}/account-settings/`}>
+            {intl.formatMessage(messages.settings)}
           </Dropdown.Item>
           { getConfig().ORDER_HISTORY_URL && (
             <Dropdown.Item href={getConfig().ORDER_HISTORY_URL}>

--- a/src/learning-header/AuthenticatedUserDropdown.jsx
+++ b/src/learning-header/AuthenticatedUserDropdown.jsx
@@ -29,7 +29,7 @@ function AuthenticatedUserDropdown({ intl, username }) {
         </Dropdown.Toggle>
         <Dropdown.Menu className="dropdown-menu-right">
           {dashboardMenuItem}
-          <Dropdown.Item href={`${getConfig().MARKETING_SITE_BASE_URL}/u/${username}`}>
+          <Dropdown.Item href={`${getConfig().MARKETING_SITE_BASE_URL}/profile/`}>
             {intl.formatMessage(messages.profile)}
           </Dropdown.Item>
           <Dropdown.Item href={`${getConfig().MARKETING_SITE_BASE_URL}/account-settings/`}>

--- a/src/learning-header/AuthenticatedUserDropdown.jsx
+++ b/src/learning-header/AuthenticatedUserDropdown.jsx
@@ -12,7 +12,7 @@ import messages from './messages';
 
 function AuthenticatedUserDropdown({ intl, username }) {
   const dashboardMenuItem = (
-    <Dropdown.Item href={`${process.env.MARKETING_SITE_BASE_URL}/dashboard`}>
+    <Dropdown.Item href={`${getConfig().MARKETING_SITE_BASE_URL}/dashboard`}>
       {intl.formatMessage(messages.dashboard)}
     </Dropdown.Item>
   );
@@ -29,7 +29,7 @@ function AuthenticatedUserDropdown({ intl, username }) {
         </Dropdown.Toggle>
         <Dropdown.Menu className="dropdown-menu-right">
           {dashboardMenuItem}
-          <Dropdown.Item href={`${process.env.MARKETING_SITE_BASE_URL}/u/${username}`}>
+          <Dropdown.Item href={`${getConfig().MARKETING_SITE_BASE_URL}/u/${username}`}>
             {intl.formatMessage(messages.profile)}
           </Dropdown.Item>
           <Dropdown.Item href={`${getConfig().LMS_BASE_URL}/account/settings`}>

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -35,7 +35,7 @@ function LearningHeader({
   const headerLogo = (
     <LinkedLogo
       className="logo"
-      href={`${getConfig().LMS_BASE_URL}/dashboard`}
+      href={`${process.env.MARKETING_SITE_BASE_URL}/dashboard`}
       src={getConfig().LOGO_URL}
       alt={getConfig().SITE_NAME}
     />

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -35,7 +35,7 @@ function LearningHeader({
   const headerLogo = (
     <LinkedLogo
       className="logo"
-      href={`${getConfig().MARKETING_SITE_BASE_URL}/dashboard`}
+      href={`${getConfig().MARKETING_SITE_BASE_URL}`}
       src={getConfig().LOGO_URL}
       alt={getConfig().SITE_NAME}
     />

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -35,7 +35,7 @@ function LearningHeader({
   const headerLogo = (
     <LinkedLogo
       className="logo"
-      href={`${process.env.MARKETING_SITE_BASE_URL}/dashboard`}
+      href={`${getConfig().MARKETING_SITE_BASE_URL}/dashboard`}
       src={getConfig().LOGO_URL}
       alt={getConfig().SITE_NAME}
     />

--- a/src/learning-header/messages.js
+++ b/src/learning-header/messages.js
@@ -21,6 +21,11 @@ const messages = defineMessages({
     defaultMessage: 'Account',
     description: 'The text for the user menu Account navigation link.',
   },
+  settings: {
+    id: 'header.menu.settings.label',
+    defaultMessage: 'Settings',
+    description: 'The text for the user menu Settings navigation link.',
+  },
   orderHistory: {
     id: 'header.menu.orderHistory.label',
     defaultMessage: 'Order History',


### PR DESCRIPTION
fixes: https://github.com/mitodl/mitxonline/issues/268
fixes: https://github.com/mitodl/mitxpro/issues/2331

From the menu in MFE in MITx Online edX, there are a couple links that need to be updated.

### Acceptance Criteria
- [ ] `MIT xPRO` icon in the upper left
   - *Currently points to:* edX dashboard (on prod: https://courses.xpro.mit.edu/dashboard)
   - *Should point to:* xPRO home page (on prod: https://xpro.mit.edu/)
- [ ] User menu `Dashboard` link
   - *Currently points to:* edX dashboard (on prod: https://courses.xpro.mit.edu/dashboard)
   - *Should point to:* xPRO dashboard (on prod: https://xpro.mit.edu/dashboard/)
- [ ] User menu `Profile` link
   - *Currently points to:* edX profile page (on prod: https://courses.xpro.mit.edu/u/[username])
   - *Should point to:* xPRO profile page (on prod: https://xpro.mit.edu/profile/)
- [ ] User menu `Account` link
   - *Note:* Should be renamed to `Settings`
   - *Note:* Ideally it would point to the xPRO settings page, but it's currently redirecting correctly. Determine if you need to update it.
   - *Currently points to:* edX settings page, which redirects to xPRO settings page (on prod: https://courses.xpro.mit.edu/account/settings)
   - *Should point to:* xPRO settings page (on prod: https://xpro.mit.edu/account-settings/)
- [ ] User menu `Order History` link
   - Should be removed
- [x] User menu `Sign Out` link
   - Works fine as is
