### PR TITLE
asadiqbal08/Added user full name option

### DIFF
--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -27,6 +27,7 @@ ensureConfig([
 subscribe(APP_CONFIG_INITIALIZED, () => {
   mergeConfig({
     AUTHN_MINIMAL_HEADER: !!process.env.AUTHN_MINIMAL_HEADER,
+    SHOW_FULLNAME: process.env.SHOW_FULLNAME
   }, 'Header additional config');
 });
 

--- a/src/learning-header/AuthenticatedUserDropdown.jsx
+++ b/src/learning-header/AuthenticatedUserDropdown.jsx
@@ -10,7 +10,7 @@ import { Dropdown } from '@edx/paragon';
 
 import messages from './messages';
 
-function AuthenticatedUserDropdown({ intl, username }) {
+function AuthenticatedUserDropdown({ intl, name }) {
   const dashboardMenuItem = (
     <Dropdown.Item href={`${getConfig().MARKETING_SITE_BASE_URL}/dashboard`}>
       {intl.formatMessage(messages.dashboard)}
@@ -24,7 +24,7 @@ function AuthenticatedUserDropdown({ intl, username }) {
         <Dropdown.Toggle variant="outline-primary">
           <FontAwesomeIcon icon={faUserCircle} className="d-md-none" size="lg" />
           <span data-hj-suppress className="d-none d-md-inline">
-            {username}
+            {name}
           </span>
         </Dropdown.Toggle>
         <Dropdown.Menu className="dropdown-menu-right">
@@ -51,7 +51,7 @@ function AuthenticatedUserDropdown({ intl, username }) {
 
 AuthenticatedUserDropdown.propTypes = {
   intl: intlShape.isRequired,
-  username: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
 };
 
 export default injectIntl(AuthenticatedUserDropdown);

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -31,7 +31,6 @@ function LearningHeader({
   courseOrg, courseNumber, courseTitle, intl, showUserDropdown,
 }) {
   const { authenticatedUser } = useContext(AppContext);
-
   const headerLogo = (
     <LinkedLogo
       className="logo"
@@ -52,7 +51,7 @@ function LearningHeader({
         </div>
         {showUserDropdown && authenticatedUser && (
           <AuthenticatedUserDropdown
-            username={authenticatedUser.username}
+            name={getConfig().SHOW_FULLNAME == 'true' ? authenticatedUser.name : authenticatedUser.username}
           />
         )}
         {showUserDropdown && !authenticatedUser && (

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -51,7 +51,7 @@ function LearningHeader({
         </div>
         {showUserDropdown && authenticatedUser && (
           <AuthenticatedUserDropdown
-            name={getConfig().SHOW_FULLNAME == 'true' ? authenticatedUser.name : authenticatedUser.username}
+            name={getConfig().SHOW_FULLNAME ? authenticatedUser.name : authenticatedUser.username}
           />
         )}
         {showUserDropdown && !authenticatedUser && (


### PR DESCRIPTION
fixes: https://github.com/mitodl/mitxpro/issues/2342

As an xPRO user, I'd like my `name` to appear in the pulldown in the header in edX rather than my `username`. 

#### Designs and Mockups

Old Header - Uses `name`
![image](https://user-images.githubusercontent.com/21342568/150280738-1fd58dfa-08f1-45cf-8aef-8089dcc37444.png)

New Header - Uses `username`
![image](https://user-images.githubusercontent.com/21342568/150280800-89a54c65-e8f7-4757-833a-47352920ce5a.png)


#### Acceptance Criteria:

- [ ] Update [frontend-component-header-mitol](https://github.com/mitodl/frontend-component-header-mitol) to default to showing the `username`, but support the ability to show the `name` in the pulldown in the upper right.
- [ ] Update xPRO to show the `name` rather than `username`

#### Related Issues:
https://github.com/mitodl/mitxpro/issues/2331